### PR TITLE
bugfix: hexagon map ignores custom center

### DIFF
--- a/src/plugins/xy-hexagons/XyHexagons.vue
+++ b/src/plugins/xy-hexagons/XyHexagons.vue
@@ -593,6 +593,9 @@ const MyComponent = defineComponent({
         // bounce our map
         if (REACT_VIEW_HANDLES[this.id]) REACT_VIEW_HANDLES[this.id](view)
 
+        // Sets the map to the specified data
+        this.$store.commit('setMapCamera', Object.assign({}, view))
+
         return
       }
 


### PR DESCRIPTION
Problems happened with several maps, so that the center of the map was not transferred. The XYHexagon plot did not transmit this data to $store. This has now been fixed.