### PR TITLE
feature/bugfix: wrong url -> better user information

### DIFF
--- a/src/layout-manager/TabbedDashboardView.vue
+++ b/src/layout-manager/TabbedDashboardView.vue
@@ -41,7 +41,7 @@
     @up="goUpOneFolder()"
   )
 
-  //- p.load-error(v-show="loadErrorMessage" @click="authorizeAfterError"): b {{ loadErrorMessage }}
+  p.load-error(v-show="loadErrorMessage" @click="authorizeAfterError"): b {{ loadErrorMessage }}
 
   .tabholder(v-show="showFooter && !isZoomed" :class="{wiide}" :style="dashWidthCalculator")
     .tabholdercontainer(:class="{wiide}")
@@ -223,7 +223,8 @@ export default defineComponent({
         if (this.fileSystem.handle) {
           this.loadErrorMessage = `Click to grant access to folder "${this.fileSystem.handle.name}"`
         } else {
-          this.loadErrorMessage = this.fileSystem.baseURL + ': Could not load'
+          this.loadErrorMessage =
+            this.fileSystem.baseURL + '/' + this.xsubfolder + ': Could not load'
         }
       }
     },


### PR DESCRIPTION
If an incorrect URL is specified, this will be displayed.

See [Issue 259](https://github.com/simwrapper/simwrapper/issues/259)

<img width="607" alt="Bildschirmfoto 2023-08-29 um 12 10 57" src="https://github.com/simwrapper/simwrapper/assets/44405087/ac263365-6e7d-473b-ae46-4c905d99a346">
<img width="593" alt="Bildschirmfoto 2023-08-29 um 12 11 14" src="https://github.com/simwrapper/simwrapper/assets/44405087/c1c4d5c0-abfe-4365-931f-080994e91be8">
