### PR TITLE
Facet plot dropdown

### DIFF
--- a/src/plugins/plotly/PlotlyDiagram.vue
+++ b/src/plugins/plotly/PlotlyDiagram.vue
@@ -224,6 +224,11 @@ const MyComponent = defineComponent({
     window.addEventListener('resize', this.changeDimensions)
     this.layout.margin = { r: 0, t: 8, b: 0, l: 50, pad: 2 }
     this.createFacets()
+
+    // Fix: If two x axes are used, the x-axis labels are not displayed correctly.
+    if (Array.isArray(this.traces[0].x[0])) {
+      this.layout.xaxis.autotickangles = [0, 90]
+    }
   },
 
   beforeDestroy() {

--- a/src/plugins/plotly/PlotlyDiagram.vue
+++ b/src/plugins/plotly/PlotlyDiagram.vue
@@ -364,7 +364,7 @@ const MyComponent = defineComponent({
       this.groupTracesByFacets(facet_col, facet_row)
 
       // If the plot is interactive, the traces are displayed in one plot so the grid is set to 1x1
-      if (this.vizDetails.interactive) {
+      if (this.vizDetails.interactive == 'dropdown') {
         this.layout.grid = { rows: 1, columns: 1 }
         this.createMenus(this.vizDetails.interactive)
       }
@@ -574,7 +574,7 @@ const MyComponent = defineComponent({
           let filterTrace = { ...trace }
 
           // If the the plot is interactive (e. g. dropdown menu), the traces are displayed in one plot
-          if (this.vizDetails.interactive) {
+          if (this.vizDetails.interactive == 'dropdown') {
             filterTrace = {
               ...trace,
               x: axis == 'y' ? filteredX : trace.x,
@@ -596,7 +596,7 @@ const MyComponent = defineComponent({
           delete filterTrace.facet_col
 
           // showlegend
-          if (this.vizDetails.interactive) {
+          if (this.vizDetails.interactive == 'dropdown') {
             filterTrace.showlegend = true
           } else {
             filterTrace.showlegend = j === 0
@@ -659,7 +659,7 @@ const MyComponent = defineComponent({
 
       // If the plot is a facetplot the dropdown menu should be created based on the facet_name. otherwise based on the group_name
       let dropdownLabel = 'group_name'
-      if (this.vizDetails.interactive) {
+      if (this.vizDetails.interactive == 'dropdown') {
         dropdownLabel = 'facet_name'
       }
 


### PR DESCRIPTION
This feature enables dropdowns in Plotly facet plots. When the plot is a facet plot and the interactive option in the YAML configuration is set to "dropdown," only one facet is displayed at a time, and the user can select different facets through the dropdown menu.