### PR TITLE
Gridmap Tooltip

### DIFF
--- a/src/plugins/grid-map/GridLayer.tsx
+++ b/src/plugins/grid-map/GridLayer.tsx
@@ -9,12 +9,15 @@ import { MAPBOX_TOKEN, REACT_VIEW_HANDLES } from '@/Globals' // Import constants
 
 import { CompleteMapData } from './GridMap.vue' // Import data types.
 
-const material = {
-  ambient: 0.64,
-  diffuse: 0.6,
-  shininess: 32,
-  specularColor: [51, 51, 51],
+type TooltipStyle = {
+  color: string
+  backgroundColor: string
 }
+
+type Tooltip = {
+  html: string
+  style: TooltipStyle
+} | null
 
 // LAYER --------------------------------------------------------
 export default function Layer({
@@ -67,6 +70,32 @@ export default function Layer({
     }
   }
 
+  function getTooltip(object: any): Tooltip {
+    if (!object?.coordinate) return null
+
+    const currentData = data.mapData[currentTimeIndex]?.values
+    if (!currentData || !currentData[object.index]) return null
+
+    const [lng, lat] = object.coordinate // Koordinaten (Längengrad, Breitengrad)
+    const rawValue = currentData[object.index]
+    const value = rawValue / (data.scaledFactor as number)
+    const roundedValue = Number(value.toFixed(6))
+    const unit = data.unit
+
+    const latDisplay = Number.isFinite(lat) ? lat.toFixed(4) : ''
+    const lngDisplay = Number.isFinite(lng) ? lng.toFixed(4) : ''
+
+    const tooltipHtml = `<b>${roundedValue} ${unit}</b><br/>${latDisplay} / ${lngDisplay}`
+    const tooltipStyle: TooltipStyle = dark
+      ? { color: '#ccc', backgroundColor: '#2a3c4f' }
+      : { color: '#223', backgroundColor: 'white' }
+
+    return {
+      html: tooltipHtml,
+      style: tooltipStyle,
+    }
+  }
+
   // Generate colors for data visualization using the specified color ramp
   const colors = colormap({
     colormap: colorRamp,
@@ -114,6 +143,7 @@ export default function Layer({
       controller={true}
       useDevicePixels={false}
       viewState={viewState}
+      getTooltip={getTooltip}
       onViewStateChange={(e: any) => handleViewState(e.viewState)}
     >
       {/* @ts-ignore */}

--- a/src/plugins/grid-map/GridMap.vue
+++ b/src/plugins/grid-map/GridMap.vue
@@ -83,6 +83,7 @@ interface VizDetail {
   mapIsIndependent?: boolean
   breakpoints?: string
   valueColumn: string
+  unit: string
 }
 
 interface GuiConfig {
@@ -210,6 +211,7 @@ const GridMap = defineComponent({
         zoom: 9,
         breakpoints: null as any,
         valueColumn: 'value',
+        unit: '',
       } as VizDetail,
       myState: {
         statusMessage: '',
@@ -416,6 +418,7 @@ const GridMap = defineComponent({
         center: this.vizDetails.center,
         zoom: this.vizDetails.zoom,
         valueColumn: this.vizDetails.valueColumn,
+        unit: this.vizDetails.unit,
       }
       this.$emit('title', this.vizDetails.title)
       this.solveProjection()
@@ -610,10 +613,14 @@ const GridMap = defineComponent({
 
       // console.log({ scaleFactor })
 
+      if (this.vizDetails.unit == undefined) {
+        this.vizDetails.unit = ''
+      }
+
       const finalData = {
         mapData: [] as MapData[],
         scaledFactor: scaleFactor as Number,
-        unit: tableName as String,
+        unit: this.vizDetails.unit,
       } as CompleteMapData
 
       const x = record.xCoords
@@ -694,6 +701,10 @@ const GridMap = defineComponent({
         this.vizDetails.valueColumn = 'value'
       }
 
+      if (this.vizDetails.unit == undefined) {
+        this.vizDetails.unit = ''
+      }
+
       // This for loop collects all the data that's used by
       for (let i = 0; i < csv.allRows[this.vizDetails.valueColumn].values.length; i++) {
         // Stores all times to calculate the range and the timeBinSize
@@ -727,6 +738,7 @@ const GridMap = defineComponent({
       const finalData = {
         mapData: [] as MapData[],
         scaledFactor: scaleFactor as Number,
+        unit: this.vizDetails.unit,
       } as CompleteMapData
 
       // map all times to their index and create a mapData object for each time

--- a/src/plugins/grid-map/GridMap.vue
+++ b/src/plugins/grid-map/GridMap.vue
@@ -31,7 +31,7 @@ import GUI from 'lil-gui'
 import { ToggleButton } from 'vue-js-toggle-button'
 import YAML from 'yaml'
 import colormap from 'colormap'
-import { hexToRgb, getColorRampHexCodes, Ramp, Style } from '@/js/ColorsAndWidths'
+import { hexToRgb, getColorRampHexCodes, Ramp } from '@/js/ColorsAndWidths'
 
 import util from '@/js/util'
 import globalStore from '@/store'
@@ -46,7 +46,6 @@ import TimeSlider from '@/components/TimeSliderV2.vue'
 
 import GridLayer from './GridLayer'
 import { ColorScheme, FileSystemConfig, Status } from '@/Globals'
-import { thresholdFreedmanDiaconis } from 'd3-array'
 import avro from '@/js/avro'
 
 // interface for each time object inside the mapData Array
@@ -64,6 +63,7 @@ export interface MapData {
 export interface CompleteMapData {
   mapData: MapData[]
   scaledFactor: Number
+  unit: String
 }
 
 interface VizDetail {
@@ -613,6 +613,7 @@ const GridMap = defineComponent({
       const finalData = {
         mapData: [] as MapData[],
         scaledFactor: scaleFactor as Number,
+        unit: tableName as String,
       } as CompleteMapData
 
       const x = record.xCoords


### PR DESCRIPTION
<img width="507" alt="Bildschirmfoto 2024-07-08 um 09 55 09" src="https://github.com/simwrapper/simwrapper/assets/44405087/aa1e65a2-a820-498f-9dfe-3c9c5a2d2720">

This feature now adds the tooltip to the Gridmap. 

To add the unit of the values just add the unit value to the .yaml

```yaml
  - type: gridmap
    unit: CO₂
    title: CO₂ Emissions
    description: per day
    height: 12.0
    file: analysis/emissions/emissions_grid_per_day.avro
    projection: EPSG:25832
    cellSize: 100
    opacity: 0.2
    maxHeight: 100
    colorRamp:
      reverse: false
      steps: 10
      ramp: greenRed
```