### PR TITLE
ShapeFile: Fixed Tooltip

### DIFF
--- a/src/plugins/shape-file/GeojsonLayer.tsx
+++ b/src/plugins/shape-file/GeojsonLayer.tsx
@@ -34,6 +34,8 @@ export default function Component({
   featureFilter = new Float32Array(0),
   cbTooltip = {} as any,
   bgLayers = {} as { [name: string]: BackgroundLayer },
+  handleClickEvent = {} as any,
+  highlightedLinkIndex = -1 as number,
 }) {
   // const features = globalStore.state.globalCache[viewId] as any[]
   const [features, setFeatures] = useState([] as any[])
@@ -160,8 +162,11 @@ export default function Component({
   }
 
   // CLICK  ---------------------------------------------------------------------
-  function handleClick() {
-    console.log('click!')
+  function handleClick(event: any) {
+    // console.log('click!')
+    // console.log(event)
+    // TODO: send click event to parent
+    if (handleClickEvent) handleClickEvent(event)
   }
 
   // TOOLTIP ------------------------------------------------------------------
@@ -211,8 +216,8 @@ export default function Component({
     getPointRadius: cbPointRadius,
     getElevation: cbFillHeight,
     // settings: ------------------------
-    autoHighlight: true,
     extruded: !!fillHeights,
+    highlightedObjectIndex: highlightedLinkIndex,
     highlightColor: [255, 0, 224],
     // lineJointRounded: true,
     lineWidthUnits: 'pixels',

--- a/src/plugins/shape-file/ShapeFile.vue
+++ b/src/plugins/shape-file/ShapeFile.vue
@@ -25,6 +25,8 @@
       :pointRadii="dataPointRadii"
       :cbTooltip="cbTooltip"
       :bgLayers="bgLayers"
+      :handleClickEvent="handleClickEvent"
+      :highlightedLinkIndex="highlightedLinkIndex"
     )
 
     //- :features="useCircles ? centroids: boundaries"
@@ -238,7 +240,9 @@ const MyComponent = defineComponent({
       boundaryJoinLookups: {} as { [column: string]: { [lookup: string | number]: number } },
       datasetValuesColumn: '',
 
-      tooltipHtml: '',
+      tooltipHtml: '' as string,
+      tooltipIsFixed: false as boolean,
+      highlightedLinkIndex: -1 as number,
 
       bgLayers: {} as { [name: string]: BackgroundLayer },
 
@@ -470,7 +474,21 @@ const MyComponent = defineComponent({
       return value
     },
 
+    async handleClickEvent(event: any) {
+      if (event.index != -1) {
+        this.cbTooltip(event.index, event)
+        this.tooltipIsFixed = true
+      } else {
+        this.tooltipIsFixed = false
+        this.highlightedLinkIndex = -1
+      }
+    },
+
     cbTooltip(index: number, object: any) {
+      if (this.tooltipIsFixed) return
+
+      this.highlightedLinkIndex = index
+
       // tooltip will show values for color settings and for width settings.
       // if there is base data, it will also show values and diff vs. base
       // for both color and width.

--- a/src/plugins/shape-file/ShapeFile.vue
+++ b/src/plugins/shape-file/ShapeFile.vue
@@ -476,16 +476,17 @@ const MyComponent = defineComponent({
 
     async handleClickEvent(event: any) {
       if (event.index != -1) {
-        this.cbTooltip(event.index, event)
+        this.cbTooltip(event.index, event, true)
         this.tooltipIsFixed = true
       } else {
         this.tooltipIsFixed = false
         this.highlightedLinkIndex = -1
+        this.tooltipHtml = ''
       }
     },
 
-    cbTooltip(index: number, object: any) {
-      if (this.tooltipIsFixed) return
+    cbTooltip(index: number, object: any, forceUpdate: boolean = false) {
+      if (this.tooltipIsFixed && !forceUpdate) return
 
       this.highlightedLinkIndex = index
 


### PR DESCRIPTION
The idea is to display a fixed tooltip after clicking on a link. Once a link is selected, it stays highlighted even if the mouse moves away, making it clear which link is currently selected. To "unfix" the tooltip, you can either click on another link or click in an empty area.

However, the implementation is a bit buggy. It takes a few milliseconds for the effect to take place after the onClick method is called.

@billyc Could you take a look and give me some feedback?