### PR TITLE
#373 Added GTFS Type to the Transit Viewer

### DIFF
--- a/src/plugins/transit-demand/Interfaces.ts
+++ b/src/plugins/transit-demand/Interfaces.ts
@@ -8,6 +8,7 @@ export interface RouteDetails {
   route: string[]
   transportMode: string
   uniqueRouteID?: number
+  gtfsRouteType?: number
 }
 
 export interface Network {
@@ -36,4 +37,5 @@ export interface NetworkLink {
 export interface TransitLine {
   id: string
   transitRoutes: RouteDetails[]
+  gtfsRouteType: number
 }

--- a/src/plugins/transit-demand/LegendBox.vue
+++ b/src/plugins/transit-demand/LegendBox.vue
@@ -7,12 +7,12 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, PropType } from 'vue'
+import { defineComponent } from 'vue'
 
 export default defineComponent({
   name: 'LegendBox',
   props: {
-    rows: { type: Array as PropType<[string, string][]>, required: true },
+    rows: { type: Array, required: true },
   },
 })
 </script>

--- a/src/plugins/transit-demand/LegendBox.vue
+++ b/src/plugins/transit-demand/LegendBox.vue
@@ -7,12 +7,12 @@
 </template>
 
 <script lang="ts">
-import { defineComponent } from 'vue'
+import { defineComponent, PropType } from 'vue'
 
 export default defineComponent({
   name: 'LegendBox',
   props: {
-    rows: { type: Array, required: true },
+    rows: { type: Array as PropType<[string, string][]>, required: true },
   },
 })
 </script>

--- a/src/plugins/transit-demand/TransitDemand.vue
+++ b/src/plugins/transit-demand/TransitDemand.vue
@@ -126,14 +126,6 @@ const DEFAULT_ROUTE_COLORS = [
   },
   {
     match: {
-      transportMode: 'tram',
-      // gtfsRouteType: [0, 900, 901, 902, 903, 904, 905, 906]
-    },
-    color: '#BE1414',
-    label: 'Tram',
-  },
-  {
-    match: {
       transportMode: 'rail',
       id: 'U*',
       // gtfsRouteType: [1, 400, 401, 402, 403, 404, 405],
@@ -165,6 +157,24 @@ const DEFAULT_ROUTE_COLORS = [
     },
     color: '#0480c1',
     label: 'Ferry',
+  },
+  {
+    match: {
+      transportMode: 'tram',
+      // gtfsRouteType: [0, 900, 901, 902, 903, 904, 905, 906]
+    },
+    color: '#BE1414',
+    label: 'Tram',
+  },
+  {
+    match: { transportMode: 'pt' },
+    color: '#00a',
+    label: 'Public Transport',
+  },
+  {
+    match: { transportMode: 'train' },
+    color: '#0a0',
+    label: 'Rail',
   },
   {
     match: { id: '**' },
@@ -263,6 +273,7 @@ const MyComponent = defineComponent({
       cfDemandLink: null as crossfilter.Dimension<any, any> | null,
       hoverWait: false,
       routeColors: [] as { match: any; color: string; label: string }[],
+      usedLabels: [] as string[],
     }
   },
 
@@ -283,7 +294,9 @@ const MyComponent = defineComponent({
     },
 
     legendRows(): string[][] {
-      return this.routeColors.map(r => [r.color, r.label])
+      return this.routeColors
+        .filter(r => this.usedLabels.includes(r.label))
+        .map(r => [r.color, r.label])
     },
   },
 
@@ -925,7 +938,8 @@ const MyComponent = defineComponent({
 
       this.loadingText = 'Summarizing departures...'
 
-      if (this.vizDetails.customRouteTypes) {
+      // Use custom colors if they exist, otherwise use defaults
+      if (this.vizDetails.customRouteTypes.length > 0) {
         this.routeColors = this.vizDetails.customRouteTypes
       } else {
         this.routeColors = DEFAULT_ROUTE_COLORS
@@ -1037,6 +1051,7 @@ const MyComponent = defineComponent({
 
     async constructDepartureFrequencyGeoJson() {
       const geojson = []
+      this.usedLabels = []
 
       for (const linkID in this._departures) {
         if (this._departures.hasOwnProperty(linkID)) {
@@ -1107,6 +1122,7 @@ const MyComponent = defineComponent({
               // Set color and quit searching after first successful match
               if (matched) {
                 color = config.color
+                if (!this.usedLabels.includes(config.label)) this.usedLabels.push(config.label)
                 break
               }
             }

--- a/src/plugins/transit-demand/TransitDemand.vue
+++ b/src/plugins/transit-demand/TransitDemand.vue
@@ -939,7 +939,7 @@ const MyComponent = defineComponent({
       this.loadingText = 'Summarizing departures...'
 
       // Use custom colors if they exist, otherwise use defaults
-      if (this.vizDetails.customRouteTypes.length > 0) {
+      if (this.vizDetails.customRouteTypes && this.vizDetails.customRouteTypes.length > 0) {
         this.routeColors = this.vizDetails.customRouteTypes
       } else {
         this.routeColors = DEFAULT_ROUTE_COLORS

--- a/src/plugins/transit-demand/TransitDemand.vue
+++ b/src/plugins/transit-demand/TransitDemand.vue
@@ -115,86 +115,20 @@ const DEFAULT_PROJECTION = 'EPSG:31468' // 31468' // 2048'
 const COLOR_CATEGORIES = 10
 const SHOW_STOPS_AT_ZOOM_LEVEL = 11
 
-// const DEFAULT_ROUTE_COLORS = [
-//   {
-//     match: { transportMode: 'rail', id: 'S*', gtfsType: [109], preferRegex: true },
-//     color: '#408335',
-//     label: 'S-Bahn',
-//     isUsed: false,
-//   },
-//   {
-//     match: {
-//       transportMode: 'rail',
-//       id: 'U*',
-//       gtfsType: [1, 400, 401, 402, 403, 404, 405],
-//       preferRegex: true,
-//     },
-//     color: '#115D91',
-//     label: 'U-Bahn',
-//     isUsed: false,
-//   },
-//   {
-//     match: { transportMode: 'tram', gtfsType: [0, 900, 901, 902, 903, 904, 905, 906] },
-//     color: '#BE1414',
-//     label: 'Tram',
-//     isUsed: false,
-//   },
-//   {
-//     match: {
-//       transportMode: 'rail',
-//       gtfsType: [2, 100, 101, 102, 103, 104, 105, 106, 107, 108],
-//     },
-//     color: 'red',
-//     label: 'Rail',
-//     isUsed: false,
-//   },
-//   {
-//     match: {
-//       transportMode: 'bus',
-//       gtfsType: [3, 700, 701, 702, 703, 704],
-//     },
-//     color: '#95276E',
-//     label: 'Bus',
-//     isUsed: false,
-//   },
-//   {
-//     match: {
-//       transportMode: 'ferry',
-//       gtfsType: [4, 1000, 1200],
-//     },
-//     color: '#0480c1',
-//     label: 'Ferry',
-//     isUsed: false,
-//   },
-//   {
-//     match: {
-//       transportMode: 'pt',
-//     },
-//     color: '#00f',
-//     label: 'Public Transport',
-//     isUsed: false,
-//   },
-//   {
-//     match: {
-//       transportMode: 'train',
-//     },
-//     color: '#080',
-//     label: 'Train Transport',
-//     isUsed: false,
-//   },
-//   { match: { id: ['**'] }, color: 'yellow', label: 'Other' },
-// ] as { match: any; color: string; label: string; isUsed: boolean }[]
-
 const DEFAULT_ROUTE_COLORS = [
   {
     match: {
       transportMode: 'bus',
+      // gtfsRouteType: [3, 700, 701, 702, 703, 704],
     },
     color: '#95276E',
     label: 'Bus',
   },
   {
-    match: { transportMode: 'tram' },
+    match: {
+      transportMode: 'tram',
+      // gtfsRouteType: [0, 900, 901, 902, 903, 904, 905, 906]
+    },
     color: '#BE1414',
     label: 'Tram',
   },
@@ -202,24 +136,33 @@ const DEFAULT_ROUTE_COLORS = [
     match: {
       transportMode: 'rail',
       id: 'U*',
+      // gtfsRouteType: [1, 400, 401, 402, 403, 404, 405],
     },
     color: '#115D91',
     label: 'U-Bahn',
   },
   {
-    match: { transportMode: 'rail', id: 'S*' },
+    match: {
+      transportMode: 'rail',
+      id: 'S*',
+      // gtfsRouteType: [109],
+    },
     color: '#408335',
     label: 'S-Bahn',
   },
   {
     match: {
       transportMode: 'rail',
+      // gtfsRouteType: [2, 100, 101, 102, 103, 104, 105, 106, 107, 108],
     },
     color: '#EC0016 ',
     label: 'Long-distance train services',
   },
   {
-    match: { transportMode: 'ferry' },
+    match: {
+      transportMode: 'ferry',
+      // gtfsRouteType: [4, 1000, 1200],
+    },
     color: '#0480c1',
     label: 'Ferry',
   },
@@ -990,6 +933,8 @@ const MyComponent = defineComponent({
       } else {
         this.routeColors = DEFAULT_ROUTE_COLORS
       }
+
+      console.log('routeColors', this.routeColors)
 
       await this.processDepartures()
 

--- a/src/plugins/transit-demand/TransitDemand.vue
+++ b/src/plugins/transit-demand/TransitDemand.vue
@@ -262,8 +262,6 @@ const MyComponent = defineComponent({
       cfDemand: null as crossfilter.Crossfilter<any> | null,
       cfDemandLink: null as crossfilter.Dimension<any, any> | null,
       hoverWait: false,
-
-      forceLegendUpdate: 0,
       routeColors: [] as { match: any; color: string; label: string }[],
     }
   },
@@ -285,7 +283,6 @@ const MyComponent = defineComponent({
     },
 
     legendRows(): string[][] {
-      this.forceLegendUpdate
       return this.routeColors.map(r => [r.color, r.label])
     },
   },
@@ -934,8 +931,6 @@ const MyComponent = defineComponent({
         this.routeColors = DEFAULT_ROUTE_COLORS
       }
 
-      console.log('routeColors', this.routeColors)
-
       await this.processDepartures()
 
       // Build the links layer and add it
@@ -1043,9 +1038,6 @@ const MyComponent = defineComponent({
     async constructDepartureFrequencyGeoJson() {
       const geojson = []
 
-      // console.log(this._departures)
-      // console.log(this._routeData)
-
       for (const linkID in this._departures) {
         if (this._departures.hasOwnProperty(linkID)) {
           const link = this._network.links[linkID] as any
@@ -1091,7 +1083,6 @@ const MyComponent = defineComponent({
             for (const config of this.routeColors) {
               let matched = true
               for (const [key, pattern] of Object.entries(config.match) as any[]) {
-                // console.log({ key, pattern })
                 const valueForThisProp = props[key]
                 // quit if route doesn't include this match property
                 if (!valueForThisProp) {
@@ -1099,6 +1090,7 @@ const MyComponent = defineComponent({
                   break
                 }
 
+                // if its the gtfsRoute type we must used inludes() instead of isMatch()
                 if (key === 'gtfsRouteType') {
                   if (!pattern.includes(valueForThisProp)) {
                     matched = false
@@ -1119,7 +1111,7 @@ const MyComponent = defineComponent({
               }
             }
             // no rules matched; sad!
-            // if (color == '#888') console.log('OHE NOES', route)
+            if (color == '#888') console.log('OHE NOES', route)
           }
 
           let line = {
@@ -1155,150 +1147,6 @@ const MyComponent = defineComponent({
 
       return { type: 'FeatureCollection', features: geojson }
     },
-
-    // async constructDepartureFrequencyGeoJson() {
-    //   const geojson = []
-
-    //   for (const linkID in this._departures) {
-    //     if (this._departures.hasOwnProperty(linkID)) {
-    //       const link = this._network.links[linkID] as any
-    //       if (!link) continue
-
-    //       let coordinates
-    //       try {
-    //         // If avroNetwork is available, get coordinates from the compressed node data
-    //         if (this.avroNetwork) {
-    //           const nodeFrom = this.avroNetwork.from[link]
-    //           const nodeTo = this.avroNetwork.to[link]
-    //           const coordsFrom = this.avroNetwork.__nodes[nodeFrom]
-    //           const coordsTo = this.avroNetwork.__nodes[nodeTo]
-    //           coordinates = [coordsFrom, coordsTo]
-    //         } else {
-    //           // Otherwise, calculate the coordinates from the direct network node data
-    //           coordinates = [
-    //             [this._network.nodes[link.from].x, this._network.nodes[link.from].y],
-    //             [this._network.nodes[link.to].x, this._network.nodes[link.to].y],
-    //           ]
-    //         }
-    //       } catch (e) {
-    //         console.warn(e)
-    //         continue
-    //       }
-
-    //       const departures = this._departures[linkID].total
-    //       let color = '#888' // Default color if no match is found
-    //       let isRail = true // Default transprtMode if no match is found
-
-    //       for (const route of this._departures[linkID].routes) {
-    //         const props = this._routeData[route] as RouteDetails
-    //         let matched = false
-
-    //         for (const config of this.routeColors) {
-    //           // Check if the regex should be preferred
-    //           if (config.match.preferRegex) {
-    //             if (config.match.id && match.isMatch(props.id, config.match.id)) {
-    //               color = config.color
-    //               matched = true
-    //               this.$set(config, 'isUsed', true)
-    //               break
-    //             }
-
-    //             // If no ID match, check the gtfsType
-    //             if (
-    //               config.match.gtfsType &&
-    //               props.gtfsRouteType &&
-    //               config.match.gtfsType.includes(props.gtfsRouteType)
-    //             ) {
-    //               color = config.color
-    //               this.$set(config, 'isUsed', true)
-    //               matched = true
-    //               break
-    //             }
-    //           } else {
-    //             // Match the gtfsType directly
-    //             if (
-    //               config.match.gtfsType &&
-    //               props.gtfsRouteType &&
-    //               config.match.gtfsType.includes(props.gtfsRouteType)
-    //             ) {
-    //               color = config.color
-    //               this.$set(config, 'isUsed', true)
-    //               matched = true
-    //               break
-    //             }
-
-    //             // Match based on regex
-    //             if (config.match.id && match.isMatch(props.id, config.match.id)) {
-    //               color = config.color
-    //               this.$set(config, 'isUsed', true)
-    //               matched = true
-    //               break
-    //             }
-    //           }
-
-    //           // Final fallback: match based on the transportMode
-    //           if (
-    //             config.match.transportMode &&
-    //             props.transportMode === config.match.transportMode
-    //           ) {
-    //             color = config.color
-    //             this.$set(config, 'isUsed', true)
-    //             matched = true
-    //             break
-    //           }
-    //         }
-    //       }
-
-    //       // Construct the line (Feature) for the current link with the calculated properties
-    //       const line = this.offsetLineByMeters(
-    //         {
-    //           type: 'Feature',
-    //           geometry: {
-    //             type: 'LineString',
-    //             coordinates: coordinates,
-    //           },
-    //           properties: {
-    //             color: color,
-    //             departures: departures,
-    //             id: linkID,
-    //             isRail: isRail,
-    //             from: link.from,
-    //             to: link.to,
-    //           },
-    //         },
-    //         15
-    //       )
-
-    //       geojson.push(line)
-    //     }
-    //   }
-
-    //   geojson.sort((a: any, b: any) => {
-    //     if (a.isRail && !b.isRail) return -1
-    //     if (b.isRail && !a.isRail) return 1
-    //     return 0
-    //   })
-
-    //   this.forceLegendUpdate++
-
-    //   return { type: 'FeatureCollection', features: geojson }
-    // },
-
-    // formatCustomRouteTypes(customRouteTypes: any) {
-    //   return customRouteTypes.map((customRoute: any) => {
-    //     return {
-    //       match: {
-    //         transportMode: customRoute.transportMode || undefined,
-    //         id: customRoute.regexp || undefined, // Falls keine regexp vorhanden ist, bleibt id undefined
-    //         gtfsType: customRoute.routeTypes || undefined, // Wenn keine routeTypes vorhanden sind, wird gtfsType undefined
-    //         preferRegex: customRoute.preferRegex || false, // Standardwert für preferRegex ist false
-    //       },
-    //       color: customRoute.color || '#000000', // Standardfarbe, falls keine definiert
-    //       label: customRoute.name || 'Unknown', // Standardlabel "Unknown", falls name fehlt
-    //       isUsed: false, // isUsed wird immer auf false gesetzt
-    //     }
-    //   })
-    // },
 
     offsetLineByMeters(line: any, metersToTheRight: number) {
       try {

--- a/src/plugins/transit-demand/TransitDemand.vue
+++ b/src/plugins/transit-demand/TransitDemand.vue
@@ -1092,7 +1092,6 @@ const MyComponent = defineComponent({
 
           for (const route of this._departures[linkID].routes) {
             const props = this._routeData[route] as any
-            // console.log({ props })
 
             // all match entries must match to select a color
             for (const config of this.routeColors) {

--- a/src/plugins/transit-demand/TransitDemand.vue
+++ b/src/plugins/transit-demand/TransitDemand.vue
@@ -1110,17 +1110,21 @@ const MyComponent = defineComponent({
 
                 // because the gtfsRouteType is an integer or an integer array micromatch doesn't work
                 if (key === 'gtfsRouteType') {
-                  if (Array.isArray(pattern) && !pattern.includes(valueForThisProp)) {
-                    matched = false
-                    break
-                  }
-
-                  if (Number.isInteger(pattern) && valueForThisProp !== pattern) {
-                    matched = false
-                    break
+                  if (Array.isArray(pattern)) {
+                    // array of gtfs values
+                    if (!pattern.includes(valueForThisProp)) {
+                      matched = false
+                      break
+                    }
+                  } else {
+                    // numeric - just one value
+                    if (valueForThisProp !== pattern) {
+                      matched = false
+                      break
+                    }
                   }
                 } else {
-                  // quit if match fails
+                  // text-match the pattern
                   if (!match.isMatch(valueForThisProp, pattern)) {
                     matched = false
                     break

--- a/src/plugins/transit-demand/TransitSupplyHelper.worker.ts
+++ b/src/plugins/transit-demand/TransitSupplyHelper.worker.ts
@@ -97,6 +97,7 @@ function processTransit() {
   const transitLines = _xml.transitXML.transitSchedule.transitLine
 
   for (const line of transitLines) {
+    // get the GTFS route type from the attributes
     const gtfsRoute =
       line.attributes?.attribute instanceof Array
         ? (line.attributes.attribute as any[]).find(

--- a/src/plugins/transit-demand/TransitSupplyHelper.worker.ts
+++ b/src/plugins/transit-demand/TransitSupplyHelper.worker.ts
@@ -97,15 +97,23 @@ function processTransit() {
   const transitLines = _xml.transitXML.transitSchedule.transitLine
 
   for (const line of transitLines) {
+    const gtfsRoute =
+      line.attributes?.attribute instanceof Array
+        ? (line.attributes.attribute as any[]).find(
+            attribute => attribute.name === 'gtfs_route_type'
+          )?.['#text'] ?? -1
+        : -1
+
     const attr: TransitLine = {
       id: line.id,
       transitRoutes: [],
+      gtfsRouteType: gtfsRoute,
     }
 
     if (!line.transitRoute) continue
 
     for (const route of line.transitRoute) {
-      const details: RouteDetails = buildTransitRouteDetails(line.id, route)
+      const details: RouteDetails = buildTransitRouteDetails(line.id, route, gtfsRoute)
       details.uniqueRouteID = uniqueRouteID++
       attr.transitRoutes.push(details)
     }
@@ -141,7 +149,7 @@ function generateStopFacilitiesFromXML() {
   }
 }
 
-function buildTransitRouteDetails(lineId: string, route: any): RouteDetails {
+function buildTransitRouteDetails(lineId: string, route: any, gtfsRoute: number): RouteDetails {
   const allDepartures = route.departures.departure
   allDepartures.sort(function (a: any, b: any) {
     const timeA = a.departureTime
@@ -160,6 +168,7 @@ function buildTransitRouteDetails(lineId: string, route: any): RouteDetails {
     firstDeparture: allDepartures[0].departureTime,
     lastDeparture: allDepartures[allDepartures.length - 1].departureTime,
     geojson: '',
+    gtfsRouteType: gtfsRoute,
   }
 
   if (Array.isArray(route.routeProfile.stop)) {


### PR DESCRIPTION
- The colors for the routes can now be defined in the .yaml file
- The routes can now also be defined via the GTFS type, whereby an array of GTFS types can be specified for each route and one of these must apply
- Only the routes that are actually available are listed in the legend
- A route can be hidden using the hide attribute

The possible yaml attributes are:

```yaml
    customRouteTypes:
    - label: 'Train'
      color: "#f00"   
      hide: true
      match:
        transportMode: "train"
        gtfsRouteType: [3]
        id: "RE*"
```

The routes can be filtered using transportMode, gtfsRouteType and id. The values can be transferred in an array or as a single string.

transportMode checks the transportMode from the transitSchedule file, gtfsRouteType checks the gtfs_route_type entry from the attributes from the transitLine from the transitSchedule file and id corresponds to the id of the transitLine. The transportMode and the id must be specified as a string or string array and the gtfsRouteType as an integer or integer array.

The .yaml then looks like this:

```yaml
header:
  tab: PT 1
  title: Public Transit Dashboard with Custom Colors
  triggerPattern: '*transitSchedule*xml*'
layout:
  viewer:
  - type: transit
    title: Transit Viewer
    description: Visualize the transit schedule.
    height: 12.0
    network: 'network.xml.gz'
    transitSchedule: 'transitSchedule.xml.gz'
    customRouteTypes:
    - label: 'Bus'
      color: '#95276E'
      match:
        transportMode: "bus"
        gtfsRouteType: [3]
    - label: 'Tram'
      color: '#BE1414'
      match:
        transportMode: "tram"
    - label: 'U-Bahn'
      color: '#115D91'
      match:
        transportMode: "rail"
        id: "U*"
    - label: 'S-Bahn'
      color: '#408335'
      match:
        transportMode: "rail"
        id: "S*"
    - label: 'Long-distance train services'
      color: '#EC0016'
      match:
        transportMode: "rail"
    - label: 'Ferry'
      color: '#0480c1'
      match:
        transportMode: "ferry"
    - label: 'Other'
      color: '#000000'
      match:
        id: "**"
```