### PR TITLE
fix: Prevent browser tab crashess due to deck.gl memory leak

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -348,7 +348,7 @@ h4 {
 #main-app {
   display: grid;
   color: var(--text);
-  // background-color: yellow; // var(--bgPanel2);
+  background-color: var(--bgDashboard);
   grid-template-columns: 1fr;
   grid-template-rows: auto auto 1fr;
   margin: 0 0;

--- a/src/components/BreadCrumbs.vue
+++ b/src/components/BreadCrumbs.vue
@@ -5,11 +5,12 @@
       i.fa.fa-home
 
   .x-breadcrumbs(v-if="root")
-    p(v-for="crumb,i in crumbs.slice(1)"
-      :key="crumb.url"
-      @click="clickedBreadcrumb(crumb)"
-    ) &nbsp;•&nbsp;{{ crumb.label }}
-    //- •&nbsp;
+    //- p(v-for="crumb,i in crumbs.slice(1)"
+    //-   :key="crumb.url"
+    //-   @click="clickedBreadcrumb(crumb)"
+    //- ) &nbsp;•&nbsp;{{ crumb.label }}
+    p(v-for="crumb,i in crumbs.slice(1)" :key="`${crumb.root}${crumb.subfolder}`")
+      a(:href="`/${crumb.root}/${crumb.subfolder}`") &nbsp;•&nbsp;{{ crumb.label }}
 
 </template>
 

--- a/src/layout-manager/TabbedDashboardView.vue
+++ b/src/layout-manager/TabbedDashboardView.vue
@@ -27,7 +27,8 @@
         :style="{opacity: tab===activeTab ? 1.0 : 0.75}"
         @click="switchLeftTab(tab,index)"
       )
-        a(v-if="dashboards[tab].header" @click="switchLeftTab(tab,index)") {{ dashboards[tab].header.tab }}
+        a(v-if="dashboards[tab].header" :href="`${$route.path}?tab=${index+1}`") {{ dashboards[tab].header.tab }}
+        //- a(v-if="dashboards[tab].header" @click="switchLeftTab(tab,index)") {{ dashboards[tab].header.tab }}
 
     .dashboard-content(
       v-if="dashboardTabWithDelay && dashboardTabWithDelay !== 'FILE__BROWSER' && dashboards[dashboardTabWithDelay] && dashboards[dashboardTabWithDelay].header.tab !== '...'"
@@ -717,12 +718,13 @@ li.is-not-active b a {
 
 .tab-list {
   font-family: $fancyFont;
-  font-size: 0.9rem;
-  line-height: 1.1rem;
-  padding: 3px 0.5rem 5px 0.5rem;
+  font-size: 1rem;
+  line-height: 0.9rem;
+  padding: 8px 0.5rem 8px 0.5rem;
   border-left: 5px solid #00000000;
   user-select: none;
   margin-bottom: 1px;
+  border-radius: 5px 5px;
 
   a {
     color: var(--text);
@@ -737,7 +739,7 @@ li.is-not-active b a {
 .tab-list.is-active {
   background-color: var(--bgBold);
   border-left: 5px solid var(--highlightActiveSection);
-  border-radius: 3px 0 0 3px;
+  border-radius: 5px 5px;
   font-weight: bold;
   a {
     color: var(--textBold);


### PR DESCRIPTION
This bug https://github.com/visgl/deck.gl/issues/9264 is making SimWrapper crash.

Upgrading to deck.gl 9.x is not otherwise urgent so as a workaround we will reload the page on major dashboard navigations. Not ideal but better than crashing.