### PR TITLE
loadLinksCsv() not needed for logistic viewer - commented out. 

### DIFF
--- a/src/plugins/logistics/LogisticsViewer.vue
+++ b/src/plugins/logistics/LogisticsViewer.vue
@@ -2144,7 +2144,7 @@ const LogisticsPlugin = defineComponent({
 
     this.lsps = await this.loadLSPS()
     this.carriers = await this.loadCarriers()
-    this.linksCsvData = await this.loadLinksCsv()
+    // this.linksCsvData = await this.loadLinksCsv()
 
     // TESTS //
 

--- a/src/plugins/transit-demand/TransitDemand.vue
+++ b/src/plugins/transit-demand/TransitDemand.vue
@@ -1174,7 +1174,7 @@ const MyComponent = defineComponent({
         this.stopLevelDemand[stopId].b += row.passengersBoarding
         this.stopLevelDemand[stopId].a += row.passengersAlighting
         const ptLineId = row.transitLine
-        if(!this.stopLevelDemand[stopId].ptLines[ptLineId]) this.stopLevelDemand[stopId].ptLines[ptLineId] = {name: ptLineId, b: 0, a:0}
+        if (!this.stopLevelDemand[stopId].ptLines[ptLineId]) this.stopLevelDemand[stopId].ptLines[ptLineId] = { name: ptLineId, b: 0, a: 0 }
         this.stopLevelDemand[stopId].ptLines[ptLineId].a += row.passengersAlighting
         this.stopLevelDemand[stopId].ptLines[ptLineId].b += row.passengersBoarding
       }


### PR DESCRIPTION
Transit viewer is here because prettier formatted it when saving.