### PR TITLE
add button for sankey diagrams to see a net migration from one mode t…

### DIFF
--- a/src/plugins/sankey/SankeyDiagram.vue
+++ b/src/plugins/sankey/SankeyDiagram.vue
@@ -6,6 +6,7 @@
   .labels(v-if="!thumbnail")
     p.center: b {{ totalTrips.toLocaleString() }} {{ $t('total') }}
 
+  b-switch.switcher(v-if="!thumbnail" v-model="onlyShowNetChanges" size="is-small") {{ $t('showNetChanges')}}
   b-switch.switcher(v-if="!thumbnail" v-model="onlyShowChanges" size="is-small") {{ $t('showChanges')}}
 
 </template>
@@ -13,8 +14,8 @@
 <script lang="ts">
 const i18n = {
   messages: {
-    en: { total: 'total', showChanges: 'Only show changes' },
-    de: { total: 'Insgesamt', showChanges: 'Nur Änderungen zeigen' },
+    en: { total: 'total', showChanges: 'Only show changes', showNetChanges: 'Only show net changes' },
+    de: { total: 'Insgesamt', showChanges: 'Nur Änderungen zeigen', showNetChanges: 'saldieren' },
   },
 }
 
@@ -34,6 +35,7 @@ import Papa from '@simwrapper/papaparse'
 import globalStore from '@/store'
 import { FileSystemConfig, VisualizationPlugin } from '@/Globals'
 import HTTPFileSystem from '@/js/HTTPFileSystem'
+import { title } from 'process'
 
 enum Size {
   small,
@@ -69,6 +71,7 @@ const MyComponent = defineComponent({
       totalTrips: 0,
       cleanConfigId: `sankey-${Math.floor(1e12 * Math.random())}` as any,
       onlyShowChanges: false,
+      onlyShowNetChanges: false,
       csvData: [] as any[],
       colorRamp: [] as string[],
       textSize: Size.small,
@@ -106,10 +109,21 @@ const MyComponent = defineComponent({
       this.getVizDetails()
     },
 
-    onlyShowChanges() {
+    onlyShowChanges(newValue) {
+      if (newValue) {
+        this.onlyShowNetChanges = false
+      }
       this.jsonChart = this.processInputs()
       this.doD3()
     },
+
+    onlyShowNetChanges(newValue) {
+      if (newValue) {
+        this.onlyShowChanges = false
+      }
+      this.jsonChart = this.processInputs()
+      this.doD3()
+    }
   },
 
   methods: {
@@ -210,6 +224,7 @@ const MyComponent = defineComponent({
           // Don't include non-changes in the graph if we are hiding them
           if (this.onlyShowChanges && cols[0] === cols[1]) continue
 
+
           links.push([cols[0], cols[1], value])
           this.totalTrips += value
         }
@@ -217,6 +232,7 @@ const MyComponent = defineComponent({
         const e = err as any
         console.error(e)
       }
+
 
       // build js object
       const fromOrder = [] as number[]
@@ -244,6 +260,35 @@ const MyComponent = defineComponent({
         toLookup[title] = offset
         toOrder.push(offset)
       })
+
+
+      if (this.onlyShowNetChanges) {
+
+        for (const link of links) {
+
+          if (link[0] != link[1]) {
+            // find reverse
+            links.forEach((subLink: any) => {
+              if (subLink[0] === link[1] && subLink[1] === link[0]) {
+                if (link[2] > subLink[2]) {
+                  link[2] = Math.abs(link[2] - subLink[2])
+                  subLink[2] = 0
+                } else if (link[2] < subLink[2]) {
+                  subLink[2] = Math.abs(subLink[2] - link[2])
+                  link[2] = 0
+                } else {
+                  link[2], subLink[2] = 0
+                }
+              }
+            })
+          } else {
+            link[2] = 0
+          }
+        }
+        console.log(links)
+      }
+
+      // something like, for from_nodes, if to_node is different, find flipped relationship and see which abosulte sum is higher - take difference and save it in answers.
 
       for (const link of links) {
         answer.links.push({
@@ -274,8 +319,8 @@ const MyComponent = defineComponent({
         this.textSize == Size.large
           ? 'bold 33px Arial'
           : this.textSize == Size.med
-          ? '24px Arial'
-          : '16px Arial'
+            ? '24px Arial'
+            : '16px Arial'
 
       let max = 0
 

--- a/src/plugins/sankey/SankeyDiagram.vue
+++ b/src/plugins/sankey/SankeyDiagram.vue
@@ -35,7 +35,6 @@ import Papa from '@simwrapper/papaparse'
 import globalStore from '@/store'
 import { FileSystemConfig, VisualizationPlugin } from '@/Globals'
 import HTTPFileSystem from '@/js/HTTPFileSystem'
-import { title } from 'process'
 
 enum Size {
   small,
@@ -285,7 +284,6 @@ const MyComponent = defineComponent({
             link[2] = 0
           }
         }
-        console.log(links)
       }
 
       // something like, for from_nodes, if to_node is different, find flipped relationship and see which abosulte sum is higher - take difference and save it in answers.


### PR DESCRIPTION
NEW: VSP requested having an option for the sankey diagram in the trips dashboard where you only see net differences. So if 115 people went from bike to car and 100 people went from car to bike, then the net would be 15 from bike to car, and car to bike would be 0.