### PR TITLE
fix: update js-yaml to patched versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -66,7 +66,7 @@
         "javascript-natural-sort": "^0.7.1",
         "js-base64": "^3.7.7",
         "js-sha256": "^0.11.0",
-        "js-yaml": "^4.1.0",
+        "js-yaml": "^4.3.1",
         "katex": "^0.16.11",
         "libxml2-wasm": "^0.4.1",
         "lil-gui": "^0.17.0",
@@ -2845,9 +2845,9 @@
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -16302,9 +16302,9 @@
       }
     },
     "node_modules/eslint/node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -17874,9 +17874,9 @@
       }
     },
     "node_modules/gray-matter/node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -19150,9 +19150,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "javascript-natural-sort": "^0.7.1",
     "js-base64": "^3.7.7",
     "js-sha256": "^0.11.0",
-    "js-yaml": "^4.1.0",
+    "js-yaml": "^4.3.1",
     "katex": "^0.16.11",
     "libxml2-wasm": "^0.4.1",
     "lil-gui": "^0.17.0",


### PR DESCRIPTION
## Summary

Update all js-yaml copies to the patched releases while preserving their existing major versions:

- direct js-yaml dependency to 4.3.1
- transitive js-yaml 3.x copies to 3.15.1

## Why

Earlier 3.x and 4.x releases are affected by the quadratic `!!omap` resolution issue described in [GHSA-5p4m-2wfm-xmqj](https://github.com/advisories/GHSA-5p4m-2wfm-xmqj), which tracks the missing backport of the CVE-2026-59870 fix. SimWrapper directly loads project and remote YAML configuration through `YAML.load()`.

## Impact

This is a patch-level dependency update with no application source changes.

## Validation

- `npm ci --dry-run --ignore-scripts --no-audit --no-fund`
- verified every locked js-yaml copy is 3.15.1 or 4.3.1
- parsed representative YAML with both patched releases
- `git diff --check`

Full dependency installation and the full build were intentionally skipped because this repository has a very large dependency tree.
